### PR TITLE
Render last computer move in the ui

### DIFF
--- a/packages/stormveil-ui/src/board.tsx
+++ b/packages/stormveil-ui/src/board.tsx
@@ -102,6 +102,14 @@ export default class Board extends React.Component<IProps, {}> {
         }
     }
 
+    private vectorVector = (v: Vector): Vector => {
+        const { a, s, z } = this.camera;
+        return [
+            (v[0] - v[1]) * s,
+            (v[0] + v[1]) * (s - a) - z,
+        ];
+    }
+
     private tileVector = (tile: IBoardTile): Vector => {
         const { a, s, z } = this.camera;
         return [
@@ -210,6 +218,17 @@ export default class Board extends React.Component<IProps, {}> {
         });
     }
 
+    private renderLastMove = () => {
+        const { game, team } = this.props;
+        const lastMove = game.history[game.history.length - 1];
+        if (turn(game) === team && lastMove) {
+            const [ ax, ay ] = this.vectorVector(lastMove[0]);
+            const [ bx, by ] = this.vectorVector(lastMove[1]);
+            return ( <line className="Board_Marker_Move" x1={ax} y1={ay} x2={bx} y2={by} markerEnd="url(#moveMarkerHead)" /> );
+        }
+        return null;
+    }
+
     private renderTileContent = (tile: IBoardTile) => {
         switch (tile.t) {
             case Tile.Attk:
@@ -252,10 +271,16 @@ export default class Board extends React.Component<IProps, {}> {
     public render() {
         return (
             <svg className="Match_Board" width="704" height="456">
+                <defs>
+                    <marker id="moveMarkerHead" orient="auto" markerWidth="2" markerHeight="4" refX="0.1" refY="2">
+                        <path d="M0,0 V4 L2,2 Z" style={{ fill: "rgba(255, 0, 0, 0.4)" }} />
+                    </marker>
+                </defs>
                 <g transform="translate(352, 37)">
                     <g className="Board_Tiles">
                         {this.renderTiles(this.renderTile)}
                     </g>
+                    {this.renderLastMove()}
                     {this.renderTileContents()}
                 </g>
             </svg>

--- a/packages/stormveil-ui/web/styles/styles.css
+++ b/packages/stormveil-ui/web/styles/styles.css
@@ -3,6 +3,11 @@
     to { stroke-dashoffset: 0; }
 }
 
+@keyframes pulse {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}
+
 @keyframes bounce {
     from { transform: translateY(0); }
     to { transform: translateY(-8px); }
@@ -62,6 +67,12 @@ h1 {
 
 .Board_Tile_Content--Ready {
     animation: bounce 500ms ease 0ms infinite alternate;
+}
+
+.Board_Marker_Move {
+    stroke: rgba(255, 0, 0, 0.4);
+    stroke-width: 3px;
+    animation: pulse 500ms ease 0ms infinite alternate;
 }
 
 .MainMenuOptionTitle {

--- a/packages/stormveil/src/state.ts
+++ b/packages/stormveil/src/state.ts
@@ -274,7 +274,7 @@ export function moves(s: IBoard, [ax, ay]: Vector): Vector[] {
 export function play(s: IState, a: Vector, b: Vector): IState {
     return {
         board: resolve(s.board, a, b),
-        history: s.history.concat([a, b]),
+        history: s.history.concat([[a, b]]),
         turn: opponent(s.turn),
         initial: s.initial,
     };


### PR DESCRIPTION
This PR renders the last move as an red arrow on the board by looking at the history object of the game state.